### PR TITLE
Bump libvirt provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ terraform {
     required_providers {
       libvirt = {
         source  = "dmacvicar/libvirt"
-        version = "0.6.3"
       }
     }
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
     required_providers {
       libvirt = {
         source  = "dmacvicar/libvirt"
-        version = "0.6.3"
+        version = ">=0.6.9"
       }
     }
 }


### PR DESCRIPTION
[FIX] `libvirt` provider requirement is now set to `>=0.6.9`