### PR TITLE
Add support to attach multiple disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Terraform module for KVM/Libvirt Virtual Machine. This module will create a KVM 
 - one NIC per domain, connected to the network using the **bridge interface**
 - setup network interface using DHCP or static configuration
 - cloud_init VM(s) configuration (Ubuntu+Netplan complient)
+- optionally add multiple extra disks
 - test the ssh connection
 
 ## Tested on
@@ -30,6 +31,7 @@ Terraform module for KVM/Libvirt Virtual Machine. This module will create a KVM 
 |index_start|From where the index start| 1
 |vm_hostname_prefix|VM hostname prefix|vm
 |memory|RAM in MB|1024
+|additional_disk_ids|List of volume ids to be attached to domain| []
 |hugepages|Use Hugepages|false
 |vcpu|Number of vCPUs|1
 |pool|Storage pool name|default
@@ -70,7 +72,7 @@ provider "libvirt" {
 
 module "vm" {
   source  = "MonolithProjects/vm/libvirt"
-  version = "1.6.0"
+  version = "1.7.1"
 
   vm_hostname_prefix = "server"
   vm_count    = 3
@@ -117,7 +119,7 @@ provider "libvirt" {
 
 module "vm" {
   source  = "MonolithProjects/vm/libvirt"
-  version = "1.6.0"
+  version = "1.7.1"
 
   vm_hostname_prefix = "server"
   vm_count    = 3
@@ -157,7 +159,48 @@ output "outputs" {
 }
 ```
 
-The shared directory from the example can be mounted inside the VM with command `sudo mount -t 9p -o trans=virtio,version=9p2000.L,rw tmp /host/tmp`
+> The shared directory from the example can be mounted inside the VM with command `sudo mount -t 9p -o trans=virtio,version=9p2000.L,rw tmp /host/tmp`
+
+Create a VM with an extra disk
+
+```
+# Creates a 50GB extra-data-disk within vms pool
+resource "libvirt_volume" "data_volume" {
+  pool = "vms"
+  name  = "extra-data-disk.qcow2"
+  format = "qcow2"
+  size = 1024*1024*1024*50
+}
+
+module "vm" {
+  source  = "MonolithProjects/vm/libvirt"
+  version = "1.7.1"
+
+  vm_hostname_prefix = "data-server"
+  base_volume_name = "debian-11-base.qcow2"
+  base_pool_name = "linked-images"
+  vm_count    = 1
+  bridge =        "bridge-dmz"
+  memory      = "4096"
+  hugepages   = false
+  vcpu        = 4
+  pool        = "vms"
+  system_volume = 25
+  additional_disk_ids = [ libvirt_volume.data_volume.id ]
+
+  dhcp        = true
+
+  ssh_admin   = "admin"
+  ssh_keys    = [ 
+    chomp(file("~/.ssh/id_rsa.pub"))
+    ]
+  time_zone   = "America/Argentina/Buenos_Aires"
+}
+
+output "ip_addresses" {
+  value = module.vm
+}
+```
 
 ## Module output example
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ provider "libvirt" {
 
 module "vm" {
   source  = "MonolithProjects/vm/libvirt"
-  version = "1.7.1"
+  version = "1.8.0"
 
   vm_hostname_prefix = "server"
   vm_count    = 3
@@ -119,7 +119,7 @@ provider "libvirt" {
 
 module "vm" {
   source  = "MonolithProjects/vm/libvirt"
-  version = "1.7.1"
+  version = "1.8.0"
 
   vm_hostname_prefix = "server"
   vm_count    = 3
@@ -174,7 +174,7 @@ resource "libvirt_volume" "data_volume" {
 
 module "vm" {
   source  = "MonolithProjects/vm/libvirt"
-  version = "1.7.1"
+  version = "1.8.0"
 
   vm_hostname_prefix = "data-server"
   base_volume_name = "debian-11-base.qcow2"

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,13 @@ resource "libvirt_domain" "virt-machine" {
     volume_id = element(libvirt_volume.volume-qcow2.*.id, count.index)
   }
 
+  dynamic "disk" {
+    for_each = var.additional_disk_ids
+    content {
+      volume_id = disk.value
+    }
+  }
+
   dynamic "filesystem" {
     for_each = var.share_filesystem.source != null ? [ var.share_filesystem.source] : []
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,11 @@ variable "base_pool_name" {
   default     = null
 }
 
+variable "additional_disk_ids" {
+  description = "List of volume ids"
+  default = []
+}
+
 
 variable "autostart" {
   description = "Autostart the domain"


### PR DESCRIPTION
I've found very useful to create a VM with more than one disk. Now module accepts a dynamic disk list to be attached. I've changed README examples with version 1.7.1 (thining new release can be 1.7.1), but if you prefer other semantic version number please feel free to ask me to change it. 