### PR TITLE
fix whitespace in volume names

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -20,7 +20,7 @@ resource "libvirt_volume" "volume-qcow2" {
 
 resource "libvirt_cloudinit_disk" "commoninit" {
   count          = var.vm_count
-  name           = format("${var.vm_hostname_prefix}_init%2d.iso", count.index + 1)
+  name           = format("${var.vm_hostname_prefix}_init%02d.iso", count.index + 1)
   user_data      = data.template_cloudinit_config.init_config[count.index].rendered
   network_config = data.template_file.network_config[count.index].rendered
   pool           = var.pool


### PR DESCRIPTION
the name generator implies 2 digit names. Since the "0" was missing, single-digit instances failed in creation when using lvm_backend

```
│ Error: error creating libvirt volume for cloudinit device tftest_init 1.iso: internal error: Child process (/sbin/lvcreate --name 'tftest_init 1.iso' -L 366K vg_raid5_backend) unexpected exit status 3:   Logical volume name "tftest_init 1.iso" is invalid.
│   Run `lvcreate --help' for more information.
│ 
│ 
│   with module.vm.libvirt_cloudinit_disk.commoninit[0],
│   on .terraform/modules/vm/storage.tf line 21, in resource "libvirt_cloudinit_disk" "commoninit":
│   21: resource "libvirt_cloudinit_disk" "commoninit" {
│ 
```