### PR TITLE
Remove references to the now deprecated template provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ No modules.
 | [libvirt_domain.virt-machine](https://registry.terraform.io/providers/dmacvicar/libvirt/latest/docs/resources/domain) | resource |
 | [libvirt_volume.base-volume-qcow2](https://registry.terraform.io/providers/dmacvicar/libvirt/latest/docs/resources/volume) | resource |
 | [libvirt_volume.volume-qcow2](https://registry.terraform.io/providers/dmacvicar/libvirt/latest/docs/resources/volume) | resource |
-| [template_cloudinit_config.init_config](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) | data source |
-| [template_file.init_config](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
-| [template_file.network_config](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [cloudinit_config.init_config](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) | data source |
 
 ## Inputs
 

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -1,29 +1,3 @@
-data "template_file" "network_config" {
-  count    = var.vm_count
-  template = file("${path.module}/templates/network_config_${var.dhcp == true ? "dhcp" : "static"}.tpl")
-  vars = {
-    ip_address    = element(var.ip_address, count.index)
-    ip_gateway    = var.ip_gateway
-    ip_nameserver = var.ip_nameserver
-    nic           = (var.share_filesystem.source == null ? "ens3" : "ens4")
-    # WA: If the shared filesystem is used, Libvirt connects Unclassified device to the 3rd position of PCI bus
-  }
-}
-
-data "template_file" "init_config" {
-  count    = var.vm_count
-  template = file("${path.module}/templates/cloud_init.tpl")
-  vars = {
-    ssh_admin          = var.ssh_admin
-    ssh_keys           = local.all_keys
-    local_admin        = var.local_admin
-    local_admin_passwd = var.local_admin_passwd
-    hostname           = format("${var.vm_hostname_prefix}%02d", count.index + var.index_start)
-    time_zone          = var.time_zone
-    runcmd             = local.runcmd
-  }
-}
-
 locals {
   all_keys = <<EOT
 [
@@ -39,7 +13,7 @@ EOT
 EOT
 }
 
-data "template_cloudinit_config" "init_config" {
+data "cloudinit_config" "init_config" {
   count         = var.vm_count
   gzip          = false
   base64_encode = false
@@ -47,6 +21,17 @@ data "template_cloudinit_config" "init_config" {
   part {
     filename     = format("init%02d.cfg", count.index + var.index_start)
     content_type = "text/cloud-config"
-    content      = data.template_file.init_config[count.index].rendered
+    content      = templatefile(
+      "${path.module}/templates/cloud_init.tpl",
+      {
+        ssh_admin          = var.ssh_admin
+        ssh_keys           = local.all_keys
+        local_admin        = var.local_admin
+        local_admin_passwd = var.local_admin_passwd
+        hostname           = format("${var.vm_hostname_prefix}%02d", count.index + var.index_start)
+        time_zone          = var.time_zone
+        runcmd             = local.runcmd
+      }
+    )
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.13"
   required_providers {

--- a/storage.tf
+++ b/storage.tf
@@ -21,7 +21,27 @@ resource "libvirt_volume" "volume-qcow2" {
 resource "libvirt_cloudinit_disk" "commoninit" {
   count          = var.vm_count
   name           = format("${var.vm_hostname_prefix}_init%02d.iso", count.index + 1)
-  user_data      = data.template_cloudinit_config.init_config[count.index].rendered
-  network_config = data.template_file.network_config[count.index].rendered
+  user_data      = templatefile(
+    "${path.module}/templates/cloud_init.tpl",
+    {
+      ssh_admin          = var.ssh_admin
+      ssh_keys           = local.all_keys
+      local_admin        = var.local_admin
+      local_admin_passwd = var.local_admin_passwd
+      hostname           = format("${var.vm_hostname_prefix}%02d", count.index + var.index_start)
+      time_zone          = var.time_zone
+      runcmd             = local.runcmd
+    }
+  )
+  network_config = templatefile(
+    "${path.module}/templates/network_config_${var.dhcp == true ? "dhcp" : "static"}.tpl",
+    {
+      ip_address    = element(var.ip_address, count.index)
+      ip_gateway    = var.ip_gateway
+      ip_nameserver = var.ip_nameserver
+      nic           = (var.share_filesystem.source == null ? "ens3" : "ens4")
+      # WA: If the shared filesystem is used, Libvirt connects Unclassified device to the 3rd position of PCI bus
+    }
+  )
   pool           = var.pool
 }


### PR DESCRIPTION
As mentioned in issue https://github.com/MonolithProjects/terraform-libvirt-vm/issues/18 , the template provider is deprecated.

This PR removes references to it and tries to adapt the code to the new recommendations. There is some code duplication that I'm unsure how to remove.